### PR TITLE
Tracing for standalone mode

### DIFF
--- a/src/WebJobs.Script/Diagnostics/BufferedTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/BufferedTraceWriter.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Config;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    // Abstract class that buffers the traces and flushes them periodically
+    // Methods of this class are thread safe.
+    // Subclass this class to provide custom buffered tracing implementation. Example: Trace to sql, trace to file, etc
+    public abstract class BufferedTraceWriter : TraceWriter, IDisposable
+    {
+        private const int LogFlushIntervalMs = 1000;
+
+        private readonly object _syncLock = new object();
+        private readonly Timer _flushTimer;
+        private readonly bool _isSystemTracesEnabled;
+
+        private ConcurrentQueue<TraceMessage> _logBuffer = new ConcurrentQueue<TraceMessage>();
+
+        protected BufferedTraceWriter(TraceLevel level, bool isSystemTracesEnabled = true) : base(level)
+        {
+            _isSystemTracesEnabled = isSystemTracesEnabled;
+
+            try
+            {
+                _flushTimer = new Timer(LogFlushIntervalMs);
+
+                // start a timer to flush accumulated logs in batches
+                _flushTimer.AutoReset = true;
+                _flushTimer.Elapsed += OnFlushLogs;
+                _flushTimer.Start();
+            }
+            catch
+            {
+                // Clean up, if the constructor throws
+                if (_flushTimer != null)
+                {
+                    _flushTimer.Dispose();
+                }
+
+                throw;
+            }
+        }
+
+        public override void Trace(TraceEvent traceEvent)
+        {
+            if (traceEvent == null)
+            {
+                throw new ArgumentNullException(nameof(traceEvent));
+            }
+
+            object value;
+            if (!_isSystemTracesEnabled &&
+                traceEvent.Properties.TryGetValue(ScriptConstants.TracePropertyIsSystemTraceKey, out value)
+                && value is bool && (bool)value)
+            {
+                // we don't want to write system traces to the user trace files
+                return;
+            }
+
+            if (Level < traceEvent.Level)
+            {
+                return;
+            }
+
+            AppendLine(traceEvent.Message);
+
+            if (traceEvent.Exception != null)
+            {
+                if (traceEvent.Exception is FunctionInvocationException ||
+                    traceEvent.Exception is AggregateException)
+                {
+                    // we want to minimize the stack traces for function invocation
+                    // failures, so we drill into the very inner exception, which will
+                    // be the script error
+                    Exception actualException = traceEvent.Exception;
+                    while (actualException.InnerException != null)
+                    {
+                        actualException = actualException.InnerException;
+                    }
+                    AppendLine(actualException.Message);
+                }
+                else
+                {
+                    AppendLine(traceEvent.Exception.ToFormattedString());
+                }
+            }
+        }
+
+        public override void Flush()
+        {
+            if (_logBuffer.Count == 0)
+            {
+                return;
+            }
+
+            ConcurrentQueue<TraceMessage> currentBuffer;
+            lock (_syncLock)
+            {
+                // Snapshot the current set of buffered logs
+                // and set a new queue. This ensures that any new
+                // logs are written to the new buffer.
+                // We do this snapshot in a lock since Flush might be
+                // called by multiple threads concurrently, and we need
+                // to ensure we only log each log once.
+                currentBuffer = _logBuffer;
+                _logBuffer = new ConcurrentQueue<TraceMessage>();
+            }
+
+            if (currentBuffer.Count == 0)
+            {
+                return;
+            }
+
+            // Flush the trace messages
+            lock (_syncLock)
+            {
+                this.FlushAsync(currentBuffer).Wait();
+            }
+        }
+
+        // Flush the traces
+        protected abstract Task FlushAsync(IEnumerable<TraceMessage> traceMessages);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _flushTimer.Dispose();
+
+                // ensure any remaining logs are flushed
+                Flush();
+            }
+        }
+
+        protected virtual void AppendLine(string line)
+        {
+            if (line == null)
+            {
+                return;
+            }
+
+            // add the line to the current buffer batch, which is flushed on a timer
+            _logBuffer.Enqueue(new TraceMessage
+            {
+                Time = DateTime.UtcNow,
+                Message = line.Trim()
+            });
+        }
+
+        private void OnFlushLogs(object sender, ElapsedEventArgs e)
+        {
+            Flush();
+        }
+    }
+
+    public class TraceMessage
+    {
+        public DateTime Time { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/FunctionTraceWriterFactory.cs
+++ b/src/WebJobs.Script/Diagnostics/FunctionTraceWriterFactory.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -20,6 +23,15 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public TraceWriter Create()
         {
+            // TODO: This needs to be fixed. Temporarily unblocking standalone scenario
+            if (ScriptHost.AzureWebJobsScriptModeStandalone.Equals(Environment.GetEnvironmentVariable(ScriptHost.AzureWebJobsScriptModeName)))
+            {
+                return new SqlTraceWriter(AmbientConnectionStringProvider.Instance.GetConnectionString("SqlTracer"),
+                                          ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteName),
+                                          _functionName,
+                                          _scriptHostConfig.HostConfig.Tracing.ConsoleLevel);
+            }
+
             if (_scriptHostConfig.FileLoggingMode != FileLoggingMode.Never)
             {
                 TraceLevel functionTraceLevel = _scriptHostConfig.HostConfig.Tracing.ConsoleLevel;

--- a/src/WebJobs.Script/Diagnostics/SqlTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/SqlTraceWriter.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics
+{
+    /**
+     * Sql based implementation of TraceWriter.
+     *
+     * Expected table definition:
+     *
+     * CREATE TABLE [functions].[logs]
+     * (
+     * [id] [int] IDENTITY(1,1) PRIMARY KEY,
+     * [timestamp] [datetime2](7) NOT NULL,
+     * [app_name] [nvarchar](max) NOT NULL,
+     * [function_name] [nvarchar](max), -- NULL is OK
+     * [message] [nvarchar](max) NOT NULL
+     * )
+     *
+     */
+    public class SqlTraceWriter : BufferedTraceWriter
+    {
+        public const string ConnectionStringName = "SqlTracer";
+
+        private readonly string _appName;
+        private readonly string _connectionString;
+        private readonly string _functionName;
+
+        public SqlTraceWriter(string connectionString, string appName, string functionName, TraceLevel level) : base(level)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (string.IsNullOrWhiteSpace(appName))
+            {
+                throw new ArgumentNullException(nameof(appName));
+            }
+
+            this._connectionString = connectionString;
+            this._appName = appName;
+            this._functionName = functionName;
+        }
+
+        public SqlTraceWriter(string connectionString, string appName, string functionName, TraceLevel level, bool isSystemLoggingEnabled) : base(level, isSystemLoggingEnabled)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentNullException(nameof(connectionString));
+            }
+
+            if (string.IsNullOrWhiteSpace(appName))
+            {
+                throw new ArgumentNullException(nameof(appName));
+            }
+
+            this._connectionString = connectionString;
+            this._appName = appName;
+            this._functionName = functionName;
+        }
+
+        protected async override Task FlushAsync(IEnumerable<TraceMessage> traceMessages)
+        {
+            var insertStatement =
+                "INSERT INTO functions.logs (timestamp, app_name, function_name, message) values(@Timestamp, @AppName, @FunctionName, @Message)";
+
+            using (SqlConnection connection = new SqlConnection(_connectionString))
+            {
+                await connection.OpenAsync();
+
+                using (SqlCommand command = new SqlCommand(insertStatement, connection))
+                {
+                    command.Parameters.Add("@Timestamp", SqlDbType.DateTime2);
+                    command.Parameters.Add("@AppName", SqlDbType.NVarChar).Value = _appName;
+                    command.Parameters.Add("@FunctionName", SqlDbType.NVarChar).Value = _functionName ?? (object)DBNull.Value;
+                    command.Parameters.Add("@Message", SqlDbType.NVarChar);
+
+                    foreach (var traceMessage in traceMessages)
+                    {
+                        command.Parameters["@Timestamp"].Value = traceMessage.Time;
+                        command.Parameters["@Message"].Value = traceMessage.Message;
+
+                        await command.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -379,6 +379,7 @@
     <Compile Include="Description\PackageRestoreResult.cs" />
     <Compile Include="Description\ScriptFunctionInvokerBase.cs" />
     <Compile Include="Description\DotNet\FSharp\FSharpCompilation.cs" />
+    <Compile Include="Diagnostics\BufferedTraceWriter.cs" />
     <Compile Include="Diagnostics\ApplicationPerformanceCounters.cs" />
     <Compile Include="Diagnostics\CompositeTraceWriter.cs" />
     <Compile Include="Description\Binding\BindingDirection.cs" />
@@ -412,6 +413,7 @@
     <Compile Include="Diagnostics\MetricEventNames.cs" />
     <Compile Include="Diagnostics\MetricsLogger.cs" />
     <Compile Include="Diagnostics\HostStartedEvent.cs" />
+    <Compile Include="Diagnostics\SqlTraceWriter.cs" />
     <Compile Include="EnvironmentSettingNames.cs" />
     <Compile Include="ErrorCodes.cs" />
     <Compile Include="Extensions\AssemblyExtensions.cs" />


### PR DESCRIPTION
- BufferedTraceWriter is an abstract class for implementing buffered trace writer implementations. It is responsible for buffering the traces and flushing periodically.
- SqlTraceWriter subclasses BufferedTraceWriter to write traces to a SQL Db
- A few tempoary workarounds are being added as part of this commit for quickly unblocking standalone scenarios. Specifically, the way SqlTraceWriter is being instantiated needs to be re-worked completely.